### PR TITLE
Add build script to produce distributable output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+dist/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ node server/server.js
 npm install
 grunt watch
 ```
+
+### To create a distributable build
+
+```
+npm install
+npm run build
+```
+
+The compiled assets will be available in the `dist/` directory, including the
+client and signalling server files.
 Remember to update your signalling server IP in `main.js` to your local IP if running on a separate device.
 
 1. Open http://localhost:2013 in browser

--- a/build.js
+++ b/build.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = __dirname;
+const distDir = path.join(projectRoot, 'dist');
+
+const itemsToCopy = [
+  'index.html',
+  'css',
+  'js',
+  'fonts',
+  'favicon.ico',
+  'package.json',
+  'server'
+];
+
+async function ensureCleanDist() {
+  await fs.promises.rm(distDir, { recursive: true, force: true });
+  await fs.promises.mkdir(distDir, { recursive: true });
+}
+
+async function copyItem(relativePath) {
+  const sourcePath = path.join(projectRoot, relativePath);
+
+  if (!fs.existsSync(sourcePath)) {
+    console.warn(`Skipping missing path: ${relativePath}`);
+    return;
+  }
+
+  const destinationPath = path.join(distDir, relativePath);
+  await fs.promises.mkdir(path.dirname(destinationPath), { recursive: true });
+  await fs.promises.cp(sourcePath, destinationPath, { recursive: true });
+}
+
+async function build() {
+  await ensureCleanDist();
+
+  for (const item of itemsToCopy) {
+    await copyItem(item);
+  }
+
+  console.log(`Build completed. Output available in ${path.relative(projectRoot, distDir)}`);
+}
+
+build().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple chat app using WebRTC",
   "main": "index.html",
   "scripts": {
+    "build": "node build.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Sher Minn Chong",


### PR DESCRIPTION
## Summary
- add a Node-based build script that prepares a clean `dist/` folder with the client and signalling server assets
- wire the script into `npm run build` and ignore the generated directory
- document the new build workflow in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee9bb3ff0832d8a6e6bc9620d01f9